### PR TITLE
Changing Hive Infestation radius to match the regular Cyst Radius (20m vs 7.5m)

### DIFF
--- a/source/lua/sg_Balance.lua
+++ b/source/lua/sg_Balance.lua
@@ -5,4 +5,8 @@
 
 // increase contamination cooldown significanlty ... because siege is about turtling!
 kContaminationCooldown = 60
-kContaminationBileSpewCount = 1 
+kContaminationBileSpewCount = 1
+
+// Match Hive Infestation radius to Cyst Infestation radius
+// Makes building siege rooms easier.
+kHiveInfestationRadius = 7.5


### PR DESCRIPTION
Right now Hive infestation will grow out to 20m, which makes building siege rooms difficult.  This also makes dealing with "classic" siege maps impossible without some heavy map editing.

Decreasing the max radius shouldn't come at too much of a cost to the Alien Comm/Gameplay.  Hive rooms aren't generally too spacious as it is, and the Hives are usually placed right beside each other.  At most, it might require a couple more cysts at Alien start to keep everything infested.