### PR TITLE
Adding FuncMaid Signal Emitter to Gorge Tunnel Entrances

### DIFF
--- a/source/lua/sg_Filehook.lua
+++ b/source/lua/sg_Filehook.lua
@@ -19,6 +19,7 @@ ModLoader.SetupFileHook( "lua/ObstacleMixin.lua", "lua/sg_ObstacleMixin.lua" , "
 -- Cyst placement will emit signal for all func_maid entites on map ( in range of 1000 )
 ModLoader.SetupFileHook( "lua/Cyst.lua", "lua/sg_Cyst.lua" , "post" )
 ModLoader.SetupFileHook( "lua/CommAbilities/Alien/Contamination.lua", "lua/sg_Contamination.lua" , "post" )
+ModLoader.SetupFileHook( "lua/TunnelEntrance.lua", "lua/sg_TunnelEntrance.lua" , "post" )
 
 -- Hook custom gui elements
 ModLoader.SetupFileHook( "lua/GUIWorldText.lua", "lua/sg_GUIScriptLoader.lua" , "post" )

--- a/source/lua/sg_FuncMaid.lua
+++ b/source/lua/sg_FuncMaid.lua
@@ -22,22 +22,23 @@ local function KillEntity(self, entity)
     end
 end
 
+-- Fetches a list of Entities of the specified Class and kills them.
+local function KillEntitiesByClassname(self, classname)
+    for _, entity in ientitylist(Shared.GetEntitiesWithClassname(classname)) do
+        if self:GetIsPointInside(entity:GetOrigin()) then
+            Shared.Message('Maid\'s cleaning duty for ' .. classname .. ' .. ' .. entity:GetId())
+            KillEntity(self, entity) -- do cleanup
+        end
+    end
+end
+
 local function FuncMaidTriggered(self)
     local front, siege, suddendeath = GetGameInfoEntity():GetSiegeTimes()
     local active = (self.type == 0 and front > 0) or (self.type == 1 and siege > 0)
     if GetGamerules():GetGameStarted() and active then
-        for _, entity in ientitylist(Shared.GetEntitiesWithClassname("Cyst")) do
-            if self:GetIsPointInside(entity:GetOrigin()) then
-                Shared.Message('Maid\'s cleaning duty for cyst .. ' .. entity:GetId())
-                KillEntity(self, entity) -- do cleanup
-            end
-        end
-        for _, entity in ientitylist(Shared.GetEntitiesWithClassname("Contamination")) do
-            if self:GetIsPointInside(entity:GetOrigin()) then
-                Shared.Message('Maid\'s cleaning duty for contamination .. ' .. entity:GetId())
-                KillEntity(self, entity) -- do cleanup
-            end
-        end
+        KillEntitiesByClassname(self, "Cyst")
+        KillEntitiesByClassname(self, "Contamination")
+        KillEntitiesByClassname(self, "TunnelEntrance")
     end
 end
 

--- a/source/lua/sg_TunnelEntrance.lua
+++ b/source/lua/sg_TunnelEntrance.lua
@@ -1,0 +1,20 @@
+-- sg_TunnelEntrance
+-- We need to prevent Gorge Tunnels from getting too close to the door which
+-- would spread infestation through it (alllowing comms to shift eggs through
+-- during pre-game)
+
+Script.Load("lua/Mixins/SignalEmitterMixin.lua")
+
+
+
+local ns2_OnInitialized = TunnelEntrance.OnInitialized
+function TunnelEntrance:OnInitialized()
+    InitMixin(self, SignalEmitterMixin)
+
+    ns2_OnInitialized(self)
+
+    if Server then
+        self:SetSignalRange(1000)
+        self:EmitSignal(0, kSignalFuncMaid)
+    end
+end


### PR DESCRIPTION
Adding FuncMaid kill signal emitter to Gorge Tunnels to prevent them from getting too close to the Front Door/Siege Door.  This will prevent infestation from getting through door, presuming mappers setup func maids correctly.

In doing so I cleaned up FuncMaid code slightly for when we might need to kill more entity types in the future.