### PR TITLE
Adding Shift Egg Commander ability to list of Tech Ids disabled before front door opens

### DIFF
--- a/source/lua/sg_TechTree_Server.lua
+++ b/source/lua/sg_TechTree_Server.lua
@@ -5,10 +5,16 @@
 
 -- disable specific techs to be available before BOTH doors are opened:
 -- - 'contamination' .. as it allows exploits
+
+-- Add to list as needed to disable techs
+local techDisableList = {
+    [kTechId.Contamination] = true,
+    [kTechId.TeleportEgg] = true
+}
+
 local ns2_SetTechNodeChanged = TechTree.SetTechNodeChanged
 function TechTree:SetTechNodeChanged(node, logMsg)
-    if node:GetTechId() == kTechId.Contamination then
-
+    if techDisableList[node:GetTechId()] then
         local front, siege, suddendeath = GetGameInfoEntity():GetSiegeTimes()
         if front > 0 and siege > 0 then
             node.available = false


### PR DESCRIPTION
Slight refactor of TechTree override to allow us to easily add more tech Ids to disable more tech before front doors open.  Also added the Shift Egg ability to this list to prevent them from being shifted past front door before it opens.